### PR TITLE
docs: add CHANGELOG, Code of Conduct, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Maintenance / refactoring
+
+## Testing
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] New tests added (if applicable)
+- [ ] Manually verified affected workflows
+
+## Checklist
+
+- [ ] `mypy` and `ruff` pass
+- [ ] `CHANGELOG.md` updated (for user-facing changes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to DFBU are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+- ci: add coverage gate (--cov-fail-under=80)
+
+## [1.2.3] — 2026-02-22
+
+AppImage build only; no feature changes.
+
+## [1.2.0] — 2026-02-06
+
+### Added
+
+- Verbose Log Mode: toggle shows full destination paths in log pane
+- Individual skip logging per file (replaces batch summaries every 10 files)
+- Hide Missing Checkbox: filter dotfiles with absent source paths
+- Edit Config, Validate Config, Export Config actions
+- Unified Browse Picker: single dialog accepts both files and directories
+
+### Changed
+
+- "Update" button renamed to "Edit" for clarity
+- Removed batch skip throttling (`SKIP_LOG_INTERVAL`)
+
+## [1.1.0] — 2026-02-04
+
+### Added
+
+- Branded theme: centralized `DFBUColors` palette + `dfbu_light.qss` stylesheet
+- Restructured tabs: Backup, Restore (with backup preview tree), Config, Logs (color-coded)
+- AppImage distribution: portable single-file binary, no dependencies required
+- Expanded dotfiles library: 300+ entries with XDG and Flatpak variants
+- Application icon (SVG/PNG) for desktop integration
+
+### Changed
+
+- Non-critical confirmation dialogs replaced with status bar messages
+
+## [1.0.0] — 2026-02-02
+
+### Added
+
+- YAML config split: `settings.yaml`, `dotfiles.yaml`, `session.yaml`
+- Mirror and archive backup modes
+- Backup verification with optional hash checking
+- Pre-restore safety backup before restore operations
+- Structured error handling with retry eligibility
+- MVVM architecture with PySide6 GUI
+
+## [0.9.2] — 2026-02-01
+
+### Changed
+
+- Removed dead `validation.py` code (leftover from removed CLI in v0.7.0)
+- Documentation updated to reflect v0.9.1 features and current architecture
+
+## [0.9.1] — 2026-02-01
+
+### Fixed
+
+- Replace Category dropdown with Tags text field in Add Dotfile dialog
+- Tags now accept comma-separated values and are optional
+- Dialog handles legacy data with `category` field
+
+## [0.7.0] — 2026-02-01
+
+### Changed
+
+- Configuration always loads from `DFBU/data/`; path no longer user-selectable
+- Migrated from TOML to YAML config format (`settings.yaml`, `dotfiles.yaml`, `session.yaml`)
+
+### Removed
+
+- Config directory selection UI from Backup tab
+- "Load Configuration..." menu action (Ctrl+O)
+- CLI application (`dfbu.py`)
+
+### Fixed
+
+- `DEFAULT_CONFIG_PATH` pointing to non-existent `.toml` file after YAML migration

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in
+this project a harassment-free experience for everyone, regardless of age,
+body size, disability, ethnicity, gender identity and expression, level of
+experience, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without permission
+- Any conduct that could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the maintainer at **dev@l3digital.net**. All complaints
+will be reviewed and investigated and will result in a response deemed
+necessary and appropriate. Maintainers who do not follow or enforce this Code
+of Conduct in good faith may face temporary or permanent repercussions.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct/


### PR DESCRIPTION
## Summary

Closes community health gaps identified during repo assessment.

- **CHANGELOG.md** — full history backfilled from 7 existing releases (v0.7.0 → v1.2.3)
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1
- **.github/pull_request_template.md** — checklist for contributors

No code changes. Note: SECURITY.md and issue templates were already present and comprehensive — the community health API underreported them.